### PR TITLE
feat/comment: 댓글 조회 API 구현 및 테스트 코드 작성 (Git 충돌 문제로 다시 올립니다.)

### DIFF
--- a/src/main/java/min/taskflow/comment/controller/CommentController.java
+++ b/src/main/java/min/taskflow/comment/controller/CommentController.java
@@ -6,7 +6,12 @@ import min.taskflow.comment.dto.request.CommentRequest;
 import min.taskflow.comment.dto.response.CommentResponse;
 import min.taskflow.comment.service.CommentService;
 import min.taskflow.common.annotation.Auth;
+import min.taskflow.common.response.ApiPageResponse;
 import min.taskflow.common.response.ApiResponse;
+import min.taskflow.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,10 +25,22 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<ApiResponse<CommentResponse>> createComment(@PathVariable Long taskId,
                                                                       @Valid @RequestBody CommentRequest request,
-                                                                      @Auth Long userId) {
+                                                                      @Auth User user) {
 
-        CommentResponse comment = commentService.createComment(taskId, request, userId);
+        CommentResponse comment = commentService.createComment(taskId, request, user.getUserId());
 
         return ApiResponse.success(comment, "댓글이 생성되었습니다.");
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiPageResponse<CommentResponse>> getComments(@PathVariable Long taskId,
+                                                                        @RequestParam(defaultValue = "0") int page,
+                                                                        @RequestParam(defaultValue = "10") int size,
+                                                                        @RequestParam(defaultValue = "newest") String sort) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CommentResponse> comments = commentService.getComments(taskId, pageable, sort);
+
+        return ApiPageResponse.success(comments, "댓글 목록을 조회했습니다.");
     }
 }

--- a/src/main/java/min/taskflow/comment/dto/response/CommentResponse.java
+++ b/src/main/java/min/taskflow/comment/dto/response/CommentResponse.java
@@ -1,11 +1,13 @@
 package min.taskflow.comment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import min.taskflow.user.dto.response.UserResponse;
 
 import java.time.LocalDateTime;
 
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CommentResponse(
 
         Long commentId,
@@ -16,4 +18,5 @@ public record CommentResponse(
         Long parentId,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
-) {}
+) {
+}

--- a/src/main/java/min/taskflow/comment/repository/CommentRepository.java
+++ b/src/main/java/min/taskflow/comment/repository/CommentRepository.java
@@ -3,11 +3,17 @@ package min.taskflow.comment.repository;
 import min.taskflow.comment.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = "user")
-    Page<Comment> findByTask_TaskId(Long taskId, Pageable pageable);
+    Page<Comment> findByTask_TaskIdAndParentIdIsNull(Long taskId, Pageable pageable);
+
+    @EntityGraph(attributePaths = "user")
+    List<Comment> findByParentId(Long parentCommentId, Sort sort);
 }

--- a/src/main/java/min/taskflow/comment/service/CommentService.java
+++ b/src/main/java/min/taskflow/comment/service/CommentService.java
@@ -13,16 +13,20 @@ import min.taskflow.task.entity.Task;
 import min.taskflow.task.service.InternalTaskService;
 import min.taskflow.user.dto.response.UserResponse;
 import min.taskflow.user.service.queryService.InternalQueryUserService;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final InternalTaskService internalTaskService;
-    private final InternalQueryUserService internalQueryUserService;
+    private final InternalTaskService taskService;
+    private final InternalQueryUserService userService;
     private final CommentMapper commentMapper;
 
     @Transactional
@@ -30,7 +34,7 @@ public class CommentService {
                                          @Valid CommentRequest request,
                                          Long userId) {
 
-        Task task = internalTaskService.findByTaskId(taskId);
+        Task task = taskService.findByTaskId(taskId);
 
         if (request.parentId() != null) {
             Comment parentComment = commentRepository.findById(request.parentId())
@@ -41,10 +45,45 @@ public class CommentService {
             }
         }
 
-        Comment comment = commentMapper.toEntity(request, task, internalQueryUserService.findByUserId(userId));
+        Comment comment = commentMapper.toEntity(request, task, userService.findByUserId(userId));
         Comment savedComment = commentRepository.save(comment);
-        UserResponse userResponse = internalQueryUserService.toUserResponse(savedComment.getUser());
+        UserResponse userResponse = userService.toUserResponse(savedComment.getUser());
 
         return commentMapper.toCommentResponse(savedComment, userResponse);
+    }
+
+    @Transactional
+    public Page<CommentResponse> getComments(Long taskId, Pageable pageable, String sort) {
+
+        taskService.findByTaskId(taskId);
+
+        Sort.Direction orderBy = sort.equals("oldest") ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sortByCreatedAt = Sort.by(orderBy, "createdAt");
+        Pageable parentPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sortByCreatedAt);
+
+        // 1. 부모 댓글 페이징 조회
+        Page<Comment> parentComments = commentRepository.findByTask_TaskIdAndParentIdIsNull(taskId, parentPageable);
+        List<CommentResponse> allComments = new ArrayList<>();
+
+        for (Comment parentComment : parentComments.getContent()) {
+            UserResponse parentUserResponse = userService.toUserResponse(parentComment.getUser());
+            CommentResponse parentResponse = commentMapper.toCommentResponse(parentComment, parentUserResponse);
+
+            // 2. 대댓글 조회
+            List<Comment> childComments = commentRepository.findByParentId(parentComment.getCommentId(), sortByCreatedAt);
+            List<CommentResponse> replies = childComments.stream()
+                    .map(childComment -> {
+                        UserResponse childUserResponse = userService.toUserResponse(childComment.getUser());
+                        return commentMapper.toCommentResponse(childComment, childUserResponse);
+                    })
+                    .toList();
+
+            allComments.add(parentResponse);
+            allComments.addAll(replies);
+        }
+
+        PageImpl<CommentResponse> comments = new PageImpl<>(allComments, pageable, parentComments.getTotalElements());
+
+        return comments;
     }
 }

--- a/src/main/java/min/taskflow/user/entity/User.java
+++ b/src/main/java/min/taskflow/user/entity/User.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "users")
 public class User extends BaseEntity {
 
     @Id

--- a/src/test/java/min/taskflow/comment/CommentRepositoryTest.java
+++ b/src/test/java/min/taskflow/comment/CommentRepositoryTest.java
@@ -1,0 +1,93 @@
+package min.taskflow.comment;
+
+import min.taskflow.comment.entity.Comment;
+import min.taskflow.comment.repository.CommentRepository;
+import min.taskflow.fixture.CommentFixture;
+import min.taskflow.fixture.TaskFixture;
+import min.taskflow.fixture.TeamFixture;
+import min.taskflow.fixture.UserFixture;
+import min.taskflow.task.entity.Task;
+import min.taskflow.team.entity.Team;
+import min.taskflow.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findByTask_TaskIdAndParentIdIsNull_부모_댓글_페이징_조회와_최신순_정렬() {
+
+        // given
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
+        Task task = TaskFixture.createTask(user);
+        em.persist(team);
+        em.persist(user);
+        em.persist(task);
+
+        for (int i = 0; i < 15; i++) {
+            Comment comment = CommentFixture.createComment((i + 1) + ". 댓글 내용", task, user);
+            commentRepository.save(comment);
+        }
+
+        em.flush();
+        em.clear();
+
+        // when
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Comment> comments = commentRepository.findByTask_TaskIdAndParentIdIsNull(task.getTaskId(), pageable);
+
+        // then
+        assertThat(comments.getContent()).hasSize(10);
+        assertThat(comments.getTotalElements()).isEqualTo(15);
+        assertThat(comments.getTotalPages()).isEqualTo(2);
+        assertThat(comments.getContent().get(0).getContent()).isEqualTo("15. 댓글 내용");
+    }
+
+    @Test
+    void findByParentId_자식_댓글_조회_오래된순_정렬() {
+
+        // given
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
+        Task task = TaskFixture.createTask(user);
+        em.persist(team);
+        em.persist(user);
+        em.persist(task);
+
+        Comment parentComment = CommentFixture.createComment("부모 댓글", task, user);
+        commentRepository.save(parentComment);
+
+        for (int i = 0; i < 5; i++) {
+            Comment childComment = CommentFixture.createComment((i + 1) + ". 자식 댓글", task, user);
+            ReflectionTestUtils.setField(childComment, "parentId", parentComment.getCommentId());
+            commentRepository.save(childComment);
+        }
+
+        // when
+        Sort sort = Sort.by(Sort.Direction.ASC, "createdAt");
+        List<Comment> childComments = commentRepository.findByParentId(parentComment.getCommentId(), sort);
+
+        // then
+        assertThat(childComments).hasSize(5);
+        assertThat(childComments.get(0).getContent()).isEqualTo("1. 자식 댓글");
+    }
+}

--- a/src/test/java/min/taskflow/comment/CommentServiceTest.java
+++ b/src/test/java/min/taskflow/comment/CommentServiceTest.java
@@ -9,9 +9,11 @@ import min.taskflow.comment.repository.CommentRepository;
 import min.taskflow.comment.service.CommentService;
 import min.taskflow.fixture.CommentFixture;
 import min.taskflow.fixture.TaskFixture;
+import min.taskflow.fixture.TeamFixture;
 import min.taskflow.fixture.UserFixture;
 import min.taskflow.task.entity.Task;
 import min.taskflow.task.service.InternalTaskService;
+import min.taskflow.team.entity.Team;
 import min.taskflow.user.dto.response.UserResponse;
 import min.taskflow.user.entity.User;
 import min.taskflow.user.service.queryService.InternalQueryUserService;
@@ -20,10 +22,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,10 +47,10 @@ public class CommentServiceTest {
     private CommentMapper commentMapper;
 
     @Mock
-    private InternalTaskService internalTaskService;
+    private InternalTaskService taskService;
 
     @Mock
-    private InternalQueryUserService internalQueryUserService;
+    private InternalQueryUserService userService;
 
     @Test
     void createComment_댓글_생성_성공() {
@@ -55,18 +60,20 @@ public class CommentServiceTest {
         Long userId = 2L;
         CommentRequest request = new CommentRequest("댓글 내용", null);
 
-        User user = UserFixture.createUser();
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
         Task task = TaskFixture.createTask(user);
         Comment comment = CommentFixture.createComment(request.content(), task, user);
+
         UserResponse userResponse = UserFixture.createUserResponse(user, userId);
         CommentResponse commentResponse = CommentFixture
                 .createCommentResponse(100L, "댓글 내용", taskId, userId, userResponse);
 
-        when(internalTaskService.findByTaskId(taskId)).thenReturn(task);
-        when(internalQueryUserService.findByUserId(userId)).thenReturn(user);
+        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(userService.findByUserId(userId)).thenReturn(user);
         when(commentMapper.toEntity(request, task, user)).thenReturn(comment);
         when(commentRepository.save(any(Comment.class))).thenReturn(comment);
-        when(internalQueryUserService.toUserResponse(user)).thenReturn(userResponse);
+        when(userService.toUserResponse(user)).thenReturn(userResponse);
         when(commentMapper.toCommentResponse(any(Comment.class), eq(userResponse))).thenReturn(commentResponse);
 
         // when
@@ -102,13 +109,14 @@ public class CommentServiceTest {
         Long parentId = 3L;
         CommentRequest request = new CommentRequest("대댓글 내용", parentId);
 
-        User user = UserFixture.createUser();
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
         Task task = TaskFixture.createTask(user);
         Task otherTask = TaskFixture.createTask(user);
         ReflectionTestUtils.setField(otherTask, "taskId", 20L);
         Comment parentComment = CommentFixture.createComment(request.content(), otherTask, user);
 
-        when(internalTaskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.findByTaskId(taskId)).thenReturn(task);
         when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
 
         // when & then
@@ -124,7 +132,8 @@ public class CommentServiceTest {
         Long parentId = 3L;
         CommentRequest request = new CommentRequest("대댓글 내용", parentId);
 
-        User user = UserFixture.createUser();
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
         Task task = TaskFixture.createTask(user);
         ReflectionTestUtils.setField(task, "taskId", 20L);
         Comment parentComment = CommentFixture.createComment("부모 댓글", task, user);
@@ -134,12 +143,12 @@ public class CommentServiceTest {
         CommentResponse commentResponse = CommentFixture
                 .createCommentResponse(200L, "대댓글 내용", taskId, userId, userResponse);
 
-        when(internalTaskService.findByTaskId(taskId)).thenReturn(task);
-        when(internalQueryUserService.findByUserId(userId)).thenReturn(user);
+        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(userService.findByUserId(userId)).thenReturn(user);
         when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
         when(commentMapper.toEntity(request, task, user)).thenReturn(childComment);
         when(commentRepository.save(any(Comment.class))).thenReturn(childComment);
-        when(internalQueryUserService.toUserResponse(user)).thenReturn(userResponse);
+        when(userService.toUserResponse(user)).thenReturn(userResponse);
         when(commentMapper.toCommentResponse(any(Comment.class), eq(userResponse))).thenReturn(commentResponse);
 
         // when
@@ -149,5 +158,48 @@ public class CommentServiceTest {
         assertNotNull(response);
         assertEquals("대댓글 내용", response.content());
         assertEquals("김철수", response.user().name());
+    }
+
+    @Test
+    void getComments_부모와_자식_댓글_조회_성공() {
+
+        // given
+        Long taskId = 1L;
+        Long userId = 2L;
+        Long parentId = 3L;
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(0, 10, sort);
+
+        Team team = TeamFixture.createTeam();
+        User user = UserFixture.createUser(team);
+        Task task = TaskFixture.createTask(user);
+        Comment parentComment = CommentFixture.createComment("부모 댓글", task, user);
+        ReflectionTestUtils.setField(parentComment, "commentId", parentId);
+        Comment childComment = CommentFixture.createComment("자식 댓글", task, user);
+
+        UserResponse userResponse = UserFixture.createUserResponse(user, userId);
+        CommentResponse parentResponse = CommentFixture
+                .createCommentResponse(10L, "부모 댓글", taskId, userId, userResponse);
+        CommentResponse childResponse = CommentFixture
+                .createCommentResponse(11L, "자식 댓글", taskId, userId, userResponse);
+
+        Page<Comment> parentComments = new PageImpl<>(List.of(parentComment), pageable, 1);
+
+        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(commentRepository.findByTask_TaskIdAndParentIdIsNull(taskId, pageable)).thenReturn(parentComments);
+        when(userService.toUserResponse(user)).thenReturn(userResponse);
+        when(commentMapper.toCommentResponse(parentComment, userResponse)).thenReturn(parentResponse);
+
+        when(commentRepository.findByParentId(parentComment.getCommentId(), sort)).thenReturn(List.of(childComment));
+        when(commentMapper.toCommentResponse(childComment, userResponse)).thenReturn(childResponse);
+
+        // when
+        Page<CommentResponse> comments = commentService.getComments(taskId, pageable, "newest");
+
+        // then
+        assertThat(comments).isNotNull();
+        assertThat(comments.getContent()).hasSize(2);
+        assertThat(comments.getContent().get(0).content()).isEqualTo("부모 댓글");
+        assertThat(comments.getContent().get(1).content()).isEqualTo("자식 댓글");
     }
 }

--- a/src/test/java/min/taskflow/fixture/CommentFixture.java
+++ b/src/test/java/min/taskflow/fixture/CommentFixture.java
@@ -5,6 +5,7 @@ import min.taskflow.comment.entity.Comment;
 import min.taskflow.task.entity.Task;
 import min.taskflow.user.dto.response.UserResponse;
 import min.taskflow.user.entity.User;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 
@@ -12,11 +13,15 @@ public class CommentFixture {
 
     public static Comment createComment(String content, Task task, User user) {
 
-        return Comment.builder()
+        Comment comment = Comment.builder()
                 .content(content)
                 .task(task)
                 .user(user)
                 .build();
+        ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+        ReflectionTestUtils.setField(comment, "updatedAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+
+        return comment;
     }
 
     public static CommentResponse createCommentResponse(Long commentId, String content, Long taskId, Long userId, UserResponse userResponse) {

--- a/src/test/java/min/taskflow/fixture/TaskFixture.java
+++ b/src/test/java/min/taskflow/fixture/TaskFixture.java
@@ -12,7 +12,7 @@ public class TaskFixture {
 
     public static Task createTask(User assignee) {
 
-        return Task.builder()
+        Task task = Task.builder()
                 .title("작업 보드 구현")
                 .description("드래그 앤 드롭 기능이 있는 작업 보드 컴포넌트를 만듭니다")
                 .status(TaskStatus.TODO)
@@ -20,5 +20,9 @@ public class TaskFixture {
                 .dueDate(LocalDateTime.of(2025, 9, 9, 12, 30))
                 .assignee(assignee)
                 .build();
+        ReflectionTestUtils.setField(task, "createdAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+        ReflectionTestUtils.setField(task, "updatedAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+
+        return task;
     }
 }

--- a/src/test/java/min/taskflow/fixture/TeamFixture.java
+++ b/src/test/java/min/taskflow/fixture/TeamFixture.java
@@ -1,0 +1,21 @@
+package min.taskflow.fixture;
+
+import min.taskflow.team.entity.Team;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+public class TeamFixture {
+
+    public static Team createTeam() {
+
+        Team team = Team.builder()
+                .name("개발팀")
+                .description("프론트엔드 및 백엔드 개발자들")
+                .build();
+        ReflectionTestUtils.setField(team, "createdAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+        ReflectionTestUtils.setField(team, "updatedAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+
+        return team;
+    }
+}

--- a/src/test/java/min/taskflow/fixture/UserFixture.java
+++ b/src/test/java/min/taskflow/fixture/UserFixture.java
@@ -1,22 +1,29 @@
 package min.taskflow.fixture;
 
+import min.taskflow.team.entity.Team;
 import min.taskflow.user.dto.response.UserResponse;
 import min.taskflow.user.entity.User;
 import min.taskflow.user.enums.UserRole;
-import min.taskflow.team.entity.Team;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
 
 public class UserFixture {
 
-    public static User createUser() {
+    public static User createUser(Team team) {
 
-        return User.builder()
+        User user = User.builder()
                 .userName("chulsoo")
                 .password("abcd1234!@#$")
                 .email("john@example.com")
                 .name("김철수")
                 .role(UserRole.USER)
-                .team(Team.builder().name("개발팀").description("프론트엔드 및 백엔드 개발자들").build())
+                .team(team)
                 .build();
+        ReflectionTestUtils.setField(user, "createdAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+        ReflectionTestUtils.setField(user, "updatedAt", LocalDateTime.of(2025, 9, 5, 15, 30));
+
+        return user;
     }
 
     public static UserResponse createUserResponse(User user, Long userId) {


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #35

## 📝 상세 내용
- 댓글 조회 API (`GET /api/tasks/{taskId}/comments`) 구현
- 댓글 조회 성공 테스트 코드 작성 (`CommentServiceTest`)
- 댓글 Repository 테스트 코드 작성 (`CommentRepositoryTest`)
- 테스트용 `TeamFixture` 클래스 생성 및 `createdAt`, `updatedAt` 필드 강제 설정
- 