### PR TITLE
feat/comment: 댓글 수정/삭제 API 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/min/taskflow/comment/controller/CommentController.java
+++ b/src/main/java/min/taskflow/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package min.taskflow.comment.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import min.taskflow.comment.dto.request.CommentRequest;
+import min.taskflow.comment.dto.request.CommentUpdateRequest;
 import min.taskflow.comment.dto.response.CommentResponse;
 import min.taskflow.comment.service.CommentService;
 import min.taskflow.common.annotation.Auth;
@@ -42,5 +43,30 @@ public class CommentController {
         Page<CommentResponse> comments = commentService.getComments(taskId, pageable, sort);
 
         return ApiPageResponse.success(comments, "댓글 목록을 조회했습니다.");
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(@PathVariable Long taskId,
+                                                                      @RequestBody CommentUpdateRequest request,
+                                                                      @PathVariable Long commentId,
+                                                                      @Auth User user) {
+
+        CommentResponse updatedComment = commentService.updateComment(taskId, request, commentId, user.getUserId());
+
+        return ApiResponse.success(updatedComment, "댓글이 수정되었습니다.");
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long taskId,
+                                                           @PathVariable Long commentId,
+                                                           @Auth User user) {
+
+        int deleteCount = commentService.deleteComment(taskId, commentId, user.getUserId());
+
+        String message = (deleteCount > 1)
+                ? "댓글과 대댓글들이 삭제되었습니다."
+                : "댓글이 삭제되었습니다.";
+
+        return ApiResponse.noContent(message);
     }
 }

--- a/src/main/java/min/taskflow/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/min/taskflow/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package min.taskflow.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+
+        @NotBlank(message = "수정할 댓글 내용을 입력해주세요.")
+        @Size(max = 255, message = "댓글은 255자까지 작성 가능합니다.")
+        String content
+) {
+}

--- a/src/main/java/min/taskflow/comment/entity/Comment.java
+++ b/src/main/java/min/taskflow/comment/entity/Comment.java
@@ -1,7 +1,10 @@
 package min.taskflow.comment.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import min.taskflow.common.entity.BaseEntity;
 import min.taskflow.task.entity.Task;
 import min.taskflow.user.entity.User;
@@ -11,18 +14,19 @@ import min.taskflow.user.entity.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
     @Column(nullable = false)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "task_id",  nullable = false)
+    @JoinColumn(name = "task_id", nullable = false)
     private Task task;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id",  nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     private Long parentId;
@@ -33,5 +37,9 @@ public class Comment extends BaseEntity {
         this.task = task;
         this.user = user;
         this.parentId = parentId;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
     }
 }

--- a/src/test/java/min/taskflow/fixture/CommentFixture.java
+++ b/src/test/java/min/taskflow/fixture/CommentFixture.java
@@ -24,6 +24,14 @@ public class CommentFixture {
         return comment;
     }
 
+    public static Comment createCommentWithId(String content, Task task, User user, Long commentId) {
+
+        Comment comment = createComment(content, task, user);
+        ReflectionTestUtils.setField(comment, "commentId", commentId);
+
+        return comment;
+    }
+
     public static CommentResponse createCommentResponse(Long commentId, String content, Long taskId, Long userId, UserResponse userResponse) {
 
         return CommentResponse.builder()

--- a/src/test/java/min/taskflow/fixture/TaskFixture.java
+++ b/src/test/java/min/taskflow/fixture/TaskFixture.java
@@ -25,4 +25,12 @@ public class TaskFixture {
 
         return task;
     }
+
+    public static Task createTaskWithId(User user, Long taskId) {
+
+        Task task = createTask(user);
+        ReflectionTestUtils.setField(task, "taskId", taskId);
+
+        return task;
+    }
 }

--- a/src/test/java/min/taskflow/fixture/TeamFixture.java
+++ b/src/test/java/min/taskflow/fixture/TeamFixture.java
@@ -18,4 +18,12 @@ public class TeamFixture {
 
         return team;
     }
+
+    public static Team createTeamWithId(Long teamId) {
+
+        Team team = createTeam();
+        ReflectionTestUtils.setField(team, "teamId", teamId);
+
+        return team;
+    }
 }

--- a/src/test/java/min/taskflow/fixture/UserFixture.java
+++ b/src/test/java/min/taskflow/fixture/UserFixture.java
@@ -26,6 +26,14 @@ public class UserFixture {
         return user;
     }
 
+    public static User createUserWithId(Team team, Long userId) {
+
+        User user = createUser(team);
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        return user;
+    }
+
     public static UserResponse createUserResponse(User user, Long userId) {
 
         return UserResponse.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #50

## 📝작업 내용
- 댓글 수정 API 구현 (PATCH /comments/{commentId})
- 삭제된 댓글은 수정 불가
- 댓글 삭제 API 구현 (DELETE /comments/{commentId})
- 본인 작성 댓글만 수정, 삭제 가능
- 삭제 시 대댓글도 함께 soft delete 처리
- 삭제된 댓글 수 반환하여 메시지 분기 처리
- CommentServiceTest에 수정/삭제 테스트 코드 추가
- Fixture 클래스 리팩토링: createUserWithId, createTaskWithId, createCommentWithId 등 반복되는 ReflectionTestUtils.setField() 캡슐화

