### PR TITLE
feat/task: 내부용 getTaskSummaryByUserId 서비스 구현

### DIFF
--- a/src/main/java/min/taskflow/comment/service/CommentService.java
+++ b/src/main/java/min/taskflow/comment/service/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
                                          @Valid CommentRequest request,
                                          Long userId) {
 
-        Task task = taskService.findByTaskId(taskId);
+        Task task = taskService.getTaskByTaskId(taskId);
 
         if (request.parentId() != null) {
             Comment parentComment = commentRepository.findById(request.parentId())
@@ -56,7 +56,7 @@ public class CommentService {
     @Transactional
     public Page<CommentResponse> getComments(Long taskId, Pageable pageable, String sort) {
 
-        taskService.findByTaskId(taskId);
+        taskService.getTaskByTaskId(taskId);
 
         Sort.Direction orderBy = sort.equals("oldest") ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sortByCreatedAt = Sort.by(orderBy, "createdAt");
@@ -120,7 +120,7 @@ public class CommentService {
     // 댓글이 해당 작업에 속하고 작성자가 요청한 사용자와 일치하는지 확인합니다.
     private Comment validateCommentAccess(Long taskId, Long commentId, Long userId) {
 
-        taskService.findByTaskId(taskId);
+        taskService.getTaskByTaskId(taskId);
 
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));

--- a/src/main/java/min/taskflow/task/controllder/TaskController.java
+++ b/src/main/java/min/taskflow/task/controllder/TaskController.java
@@ -7,7 +7,7 @@ import min.taskflow.task.dto.condition.TaskSearchCondition;
 import min.taskflow.task.dto.request.StatusUpdateRequest;
 import min.taskflow.task.dto.request.TaskCreateRequest;
 import min.taskflow.task.dto.request.TaskUpdateRequest;
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.service.commandService.ExternalCommandTaskService;
 import min.taskflow.task.service.queryService.ExternalQueryTaskService;
 import org.springframework.data.domain.Page;

--- a/src/main/java/min/taskflow/task/dto/response/dashboard/TaskSummaryResponse.java
+++ b/src/main/java/min/taskflow/task/dto/response/dashboard/TaskSummaryResponse.java
@@ -1,0 +1,21 @@
+package min.taskflow.task.dto.response.dashboard;
+
+import lombok.Builder;
+import min.taskflow.task.entity.Status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record TaskSummaryResponse(List<TaskSummaryDto> todayTasks,
+                                  List<TaskSummaryDto> upcomingTasks,
+                                  List<TaskSummaryDto> overdueTasks
+) {
+
+
+    public record TaskSummaryDto(Long taskId,
+                                 String title,
+                                 Status status,
+                                 LocalDateTime dueDate) {
+    }
+}

--- a/src/main/java/min/taskflow/task/dto/response/task/TaskResponse.java
+++ b/src/main/java/min/taskflow/task/dto/response/task/TaskResponse.java
@@ -1,4 +1,4 @@
-package min.taskflow.task.dto.response;
+package min.taskflow.task.dto.response.task;
 
 import lombok.Builder;
 import min.taskflow.task.entity.Priority;

--- a/src/main/java/min/taskflow/task/mapper/TaskMapper.java
+++ b/src/main/java/min/taskflow/task/mapper/TaskMapper.java
@@ -1,7 +1,8 @@
 package min.taskflow.task.mapper;
 
 import min.taskflow.task.dto.request.TaskCreateRequest;
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.dashboard.TaskSummaryResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Status;
 import min.taskflow.task.entity.Task;
 import min.taskflow.user.dto.response.UserSearchAndAssigneeResponse;

--- a/src/main/java/min/taskflow/task/mapper/TaskMapper.java
+++ b/src/main/java/min/taskflow/task/mapper/TaskMapper.java
@@ -8,6 +8,8 @@ import min.taskflow.task.entity.Task;
 import min.taskflow.user.dto.response.UserSearchAndAssigneeResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class TaskMapper {
 
@@ -37,5 +39,27 @@ public class TaskMapper {
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .build();
+    }
+
+    public TaskSummaryResponse toTaskSummaryResponse(List<Task> todayTasks,
+                                                     List<Task> upcomingTasks,
+                                                     List<Task> overdueTasks) {
+
+        return TaskSummaryResponse.builder()
+                .todayTasks(toTaskSummaryDtos(todayTasks))
+                .upcomingTasks(toTaskSummaryDtos(upcomingTasks))
+                .overdueTasks(toTaskSummaryDtos(overdueTasks))
+                .build();
+    }
+
+    private List<TaskSummaryResponse.TaskSummaryDto> toTaskSummaryDtos(List<Task> tasks) {
+        return tasks.stream()
+                .map(task -> new TaskSummaryResponse.TaskSummaryDto(
+                        task.getTaskId(),
+                        task.getTitle(),
+                        task.getStatus(),
+                        task.getDueDate()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/min/taskflow/task/repository/TaskRepository.java
+++ b/src/main/java/min/taskflow/task/repository/TaskRepository.java
@@ -1,6 +1,6 @@
 package min.taskflow.task.repository;
 
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Status;
 import min.taskflow.task.entity.Task;
 import org.springframework.data.domain.Page;

--- a/src/main/java/min/taskflow/task/repository/TaskRepository.java
+++ b/src/main/java/min/taskflow/task/repository/TaskRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,4 +29,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     Page<TaskResponse> findByTitleContaining(String query, Pageable pageable);
 
     Page<TaskResponse> findByAssigneeId(Long aLong, Pageable pageable);
+
+    List<Task> findByAssigneeIdAndDueDateBetween(Long assigneeId, LocalDateTime dueDateAfter, LocalDateTime dueDateBefore);
+
+    List<Task> findByAssigneeIdAndDueDateAfter(Long assigneeId, LocalDateTime dueDateAfter);
+
+    List<Task> findByAssigneeIdAndDueDateBefore(Long assigneeId, LocalDateTime dueDateBefore);
 }

--- a/src/main/java/min/taskflow/task/service/commandService/ExternalCommandTaskService.java
+++ b/src/main/java/min/taskflow/task/service/commandService/ExternalCommandTaskService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import min.taskflow.task.dto.request.StatusUpdateRequest;
 import min.taskflow.task.dto.request.TaskCreateRequest;
 import min.taskflow.task.dto.request.TaskUpdateRequest;
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Task;
 import min.taskflow.task.exception.TaskErrorCode;
 import min.taskflow.task.exception.TaskException;

--- a/src/main/java/min/taskflow/task/service/queryService/ExternalQueryTaskService.java
+++ b/src/main/java/min/taskflow/task/service/queryService/ExternalQueryTaskService.java
@@ -2,7 +2,7 @@ package min.taskflow.task.service.queryService;
 
 import lombok.RequiredArgsConstructor;
 import min.taskflow.task.dto.condition.TaskSearchCondition;
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Status;
 import min.taskflow.task.entity.Task;
 import min.taskflow.task.exception.TaskErrorCode;

--- a/src/main/java/min/taskflow/task/service/queryService/InternalQueryTaskService.java
+++ b/src/main/java/min/taskflow/task/service/queryService/InternalQueryTaskService.java
@@ -13,7 +13,8 @@ public class InternalQueryTaskService {
 
     private final TaskRepository taskRepository;
 
-    public Task findByTaskId(Long taskId) {
+    // TASK Id를 통해 TASK를 조회
+    public Task getTaskByTaskId(Long taskId) {
 
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));

--- a/src/main/java/min/taskflow/task/service/queryService/InternalQueryTaskService.java
+++ b/src/main/java/min/taskflow/task/service/queryService/InternalQueryTaskService.java
@@ -1,17 +1,25 @@
 package min.taskflow.task.service.queryService;
 
 import lombok.RequiredArgsConstructor;
+import min.taskflow.task.dto.response.dashboard.TaskSummaryResponse;
 import min.taskflow.task.entity.Task;
 import min.taskflow.task.exception.TaskErrorCode;
 import min.taskflow.task.exception.TaskException;
+import min.taskflow.task.mapper.TaskMapper;
 import min.taskflow.task.repository.TaskRepository;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InternalQueryTaskService {
 
     private final TaskRepository taskRepository;
+    private final TaskMapper taskMapper;
 
     // TASK Id를 통해 TASK를 조회
     public Task getTaskByTaskId(Long taskId) {
@@ -20,5 +28,21 @@ public class InternalQueryTaskService {
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         return task;
+    }
+
+    // DashBoard로 todayTasks, upcomingTasks, overdueTasks에 대한 리스트를 반환
+    public TaskSummaryResponse getTaskSummaryByUserId(Long LoginUserId) {
+
+        LocalDate baseDate = LocalDate.now();
+        LocalDateTime startOfDay = baseDate.atStartOfDay();
+        LocalDateTime endOfDay = baseDate.atTime(LocalTime.MAX);
+
+        List<Task> todayTasks = taskRepository.findByAssigneeIdAndDueDateBetween(LoginUserId, startOfDay, endOfDay);
+        List<Task> upcomingTasks = taskRepository.findByAssigneeIdAndDueDateAfter(LoginUserId, startOfDay.plusDays(1));
+        List<Task> overdueTasks = taskRepository.findByAssigneeIdAndDueDateBefore(LoginUserId, startOfDay);
+
+        TaskSummaryResponse taskSummaryResponse = taskMapper.toTaskSummaryResponse(todayTasks, upcomingTasks, overdueTasks);
+
+        return taskSummaryResponse;
     }
 }

--- a/src/test/java/min/taskflow/comment/CommentServiceTest.java
+++ b/src/test/java/min/taskflow/comment/CommentServiceTest.java
@@ -70,7 +70,7 @@ public class CommentServiceTest {
         CommentResponse commentResponse = CommentFixture
                 .createCommentResponse(100L, "댓글 내용", taskId, userId, userResponse);
 
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(userService.findByUserId(userId)).thenReturn(user);
         when(commentMapper.toEntity(request, task, user)).thenReturn(comment);
         when(commentRepository.save(any(Comment.class))).thenReturn(comment);
@@ -116,7 +116,7 @@ public class CommentServiceTest {
         Task otherTask = TaskFixture.createTaskWithId(user, 20L);
         Comment parentComment = CommentFixture.createComment(request.content(), otherTask, user);
 
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
 
         // when & then
@@ -142,7 +142,7 @@ public class CommentServiceTest {
         CommentResponse commentResponse = CommentFixture
                 .createCommentResponse(200L, "대댓글 내용", taskId, userId, userResponse);
 
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(userService.findByUserId(userId)).thenReturn(user);
         when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
         when(commentMapper.toEntity(request, task, user)).thenReturn(childComment);
@@ -183,7 +183,7 @@ public class CommentServiceTest {
 
         Page<Comment> parentComments = new PageImpl<>(List.of(parentComment), pageable, 1);
 
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(commentRepository.findByTask_TaskIdAndParentIdIsNull(taskId, pageable)).thenReturn(parentComments);
         when(userService.toUserResponse(user)).thenReturn(userResponse);
         when(commentMapper.toCommentResponse(parentComment, userResponse)).thenReturn(parentResponse);
@@ -219,7 +219,7 @@ public class CommentServiceTest {
         CommentResponse expectedResponse = CommentFixture.createCommentResponse(commentId, "수정된 내용", taskId, userId, userResponse);
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(userService.toUserResponse(user)).thenReturn(userResponse);
         when(commentMapper.toCommentResponse(comment, userResponse)).thenReturn(expectedResponse);
 
@@ -262,7 +262,7 @@ public class CommentServiceTest {
         comment.delete(); // 삭제 처리
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
 
         // when & then
         assertThrows(CommentException.class, () -> commentService.updateComment(taskId, request, commentId, userId));
@@ -283,7 +283,7 @@ public class CommentServiceTest {
         Comment comment = CommentFixture.createComment("원래 내용", task, user);
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
 
         // when & then
         assertThrows(CommentException.class, () -> commentService.updateComment(taskId, request, commentId, userId));
@@ -303,7 +303,7 @@ public class CommentServiceTest {
         Comment comment = CommentFixture.createCommentWithId("댓글 내용", task, user, commentId);
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(commentRepository.findByParentId(commentId, Sort.unsorted())).thenReturn(List.of());
 
         // when
@@ -332,7 +332,7 @@ public class CommentServiceTest {
         ReflectionTestUtils.setField(childComment2, "parentId", commentId);
 
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(parentComment));
-        when(taskService.findByTaskId(taskId)).thenReturn(task);
+        when(taskService.getTaskByTaskId(taskId)).thenReturn(task);
         when(commentRepository.findByParentId(commentId, Sort.unsorted()))
                 .thenReturn(List.of(childComment1, childComment2));
 

--- a/src/test/java/min/taskflow/task/TaskServiceTest.java
+++ b/src/test/java/min/taskflow/task/TaskServiceTest.java
@@ -1,7 +1,7 @@
 package min.taskflow.task;
 
 import min.taskflow.task.dto.request.TaskCreateRequest;
-import min.taskflow.task.dto.response.TaskResponse;
+import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Priority;
 import min.taskflow.task.entity.Task;
 import min.taskflow.task.mapper.TaskMapper;


### PR DESCRIPTION
## #️⃣연관된 이슈

- Close #58 
- Related #이슈번호

## 📝작업 내용

로그인한 유저의 아이디를 받아 해당 유저가 assignee인 TASK를 기간에 따라 조회
당일 TASK, 예정 TASK, 종료된 TASK (기준 - 당일 연,월,일)

#### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

