### PR TITLE
feat/task: 내부용 getDashboardStatsByUserId 서비스 구현

### DIFF
--- a/src/main/java/min/taskflow/task/dto/response/dashboard/TaskDashboardStatsResponse.java
+++ b/src/main/java/min/taskflow/task/dto/response/dashboard/TaskDashboardStatsResponse.java
@@ -1,0 +1,14 @@
+package min.taskflow.task.dto.response.dashboard;
+
+import lombok.Builder;
+
+@Builder
+public record TaskDashboardStatsResponse(Long totalTasks,
+                                         Long completedTasks,
+                                         Long inProgressTasks,
+                                         Long todoTasks,
+                                         Long overdueTasks,
+                                         Long teamProgress,
+                                         Long myTasksToday,
+                                         Long completionRate) {
+}

--- a/src/main/java/min/taskflow/task/mapper/TaskMapper.java
+++ b/src/main/java/min/taskflow/task/mapper/TaskMapper.java
@@ -1,6 +1,7 @@
 package min.taskflow.task.mapper;
 
 import min.taskflow.task.dto.request.TaskCreateRequest;
+import min.taskflow.task.dto.response.dashboard.TaskDashboardStatsResponse;
 import min.taskflow.task.dto.response.dashboard.TaskSummaryResponse;
 import min.taskflow.task.dto.response.task.TaskResponse;
 import min.taskflow.task.entity.Status;
@@ -53,6 +54,7 @@ public class TaskMapper {
     }
 
     private List<TaskSummaryResponse.TaskSummaryDto> toTaskSummaryDtos(List<Task> tasks) {
+
         return tasks.stream()
                 .map(task -> new TaskSummaryResponse.TaskSummaryDto(
                         task.getTaskId(),
@@ -61,5 +63,26 @@ public class TaskMapper {
                         task.getDueDate()
                 ))
                 .toList();
+    }
+
+    public TaskDashboardStatsResponse toTaskDashboardStatsResponse(Long totalTasks,
+                                                                   Long completedTasks,
+                                                                   Long inProgressTasks,
+                                                                   Long todoTasks,
+                                                                   Long overdueTasks,
+                                                                   Long teamProgress,
+                                                                   Long myTasksToday,
+                                                                   Long completionRate) {
+
+        return TaskDashboardStatsResponse.builder()
+                .totalTasks(totalTasks)
+                .completedTasks(completedTasks)
+                .inProgressTasks(inProgressTasks)
+                .todoTasks(todoTasks)
+                .overdueTasks(overdueTasks)
+                .teamProgress(teamProgress)
+                .myTasksToday(myTasksToday)
+                .completionRate(completionRate)
+                .build();
     }
 }

--- a/src/main/java/min/taskflow/task/repository/TaskRepository.java
+++ b/src/main/java/min/taskflow/task/repository/TaskRepository.java
@@ -35,4 +35,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findByAssigneeIdAndDueDateAfter(Long assigneeId, LocalDateTime dueDateAfter);
 
     List<Task> findByAssigneeIdAndDueDateBefore(Long assigneeId, LocalDateTime dueDateBefore);
+
+    Long countByAssigneeIdInAndStatus(List<Long> userIds, Status status);
+
+    Long countByAssigneeIdAndDueDateBefore(Long assigneeId, LocalDateTime dueDateBefore);
+
+    Long countByAssigneeIdAndDueDateBetween(Long assigneeId, LocalDateTime dueDateAfter, LocalDateTime dueDateBefore);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Close #60 
- Related #이슈번호

## 📝작업 내용

totalTasks = 전체
completedTasks = 완료
inProgressTasks = 진행중
todoTasks = 예정
overdueTasks = 기한만료 ( 완료된 기한만료 TASK도 여기 포함시켰음  )
teamProgress = 팀 진행 TASK (((completedTasks + inProgressTasks) / totalTasks) * 100)
myTasksToday = 당일 진행 TASK
completionRate = 완료율 (completedTasks/totalTasks*100) - 내림(1000개의 태스크 중 995개 이상의 TASK가 완료됐을때 혼란 방지)

#### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


